### PR TITLE
Fixed typographical error, changed Carribean to Caribbean in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Just open the project in Visual Studio, and build it. You may need to specify th
 * 3DS
 * Common Compressors
 * Common Files
-* Lego Pirates of the Carribean
+* Lego Pirates of the Caribbean
 * Mario Kart
 * NDS


### PR DESCRIPTION
Gericom, I've corrected a typographical error in the documentation of the [EveryFileExplorer](https://github.com/Gericom/EveryFileExplorer) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.